### PR TITLE
Mobile ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "babel-core": "^6.4.5",
     "onesie-toggle-environment-block": "latest",
+    "radium": "^0.17.1",
     "react": "^0.14.7",
     "react-addons-update": "^15.2.0",
     "react-dom": "^0.14.7",

--- a/src/app/components/assembly.jsx
+++ b/src/app/components/assembly.jsx
@@ -9,25 +9,34 @@ import * as actionCreators from '../actions/actionCreators';
 
 
 function mapStateToProps(state){
-  return {
-    organizations: state.organizations
-  };
+  return { organizations: state.organizations };
 }
 
 function mapDispatchToProps(dispatch) {
   return bindActionCreators(actionCreators, dispatch);
 }
 
+const assemblyInnerStyles = {
+  margin:'10px 10px 10px 10px',
+  height: 'auto',
+  background: '#f0f0f5',
+  border: '1px solid gray',
+  boxShadow: '0 2px 4px rgba(0, 0, 0, .48)',
+  overflow:'hidden'
+};
+
+const paragraphStyles = {
+  fontSize: '18px',
+  color: '#111',
+  paddingLeft: '20px'
+};
+
 class Assembly extends React.Component{
 
-  componentDidMount() {
-    this.getEnvironments(this.props.item);
-
-  }
+  componentDidMount() { this.getEnvironments(this.props.item); }
 
   getEnvironments(assem) {
-    var org = this.props.organization;
-
+    const org = this.props.organization;
     envs(this.error,{ooOrganization:org , ooAssembly:assem.ciName}, (envsObjs) => {
       this.props.setEnvironments(org, this.props.item , envsObjs);
     });
@@ -35,16 +44,14 @@ class Assembly extends React.Component{
 
   renderEnvironments() {
     return _.map(this.props.item.environments, (item, index) => {
-      var data = {
+      const data = {
         id: item.ciId ,
         name: item.ciName , 
         status: 'Success',
         version: item.impl
       };
 
-      return (
-        <ClusterToggleView key={index} mode="thumbnail" environment={data}></ClusterToggleView>
-      );
+      return (<ClusterToggleView key={index} mode="thumbnail" environment={data}/>);
     });
   }
 
@@ -52,14 +59,12 @@ class Assembly extends React.Component{
 
   render() {
     return (
-        <div>
-          {
-            this.renderEnvironments()
-          }
-        </div>
+      <div style={assemblyInnerStyles}>
+        <b style={paragraphStyles}>{this.props.item.ciName}</b>
+        {this.renderEnvironments()}
+      </div>
     );
   }
-
 }
 
 Assembly.propTypes = {
@@ -69,6 +74,4 @@ Assembly.propTypes = {
 };
 
 const ConnectedAssembly = connect(mapStateToProps , mapDispatchToProps)(Assembly);
-
-
 export default ConnectedAssembly;

--- a/src/app/components/scroll.jsx
+++ b/src/app/components/scroll.jsx
@@ -3,34 +3,6 @@ import React from 'react';
 import ScrollArea from 'react-scrollbar';
 import Assembly from './assembly.jsx';
 
-const assemblyStyles = {
-  width: '100%',
-  padding: '0px 10px 25% 10px',
-  fontSize: '18px',
-  boxSizing: 'border-box',
-  position: 'relative',
-  color: '#d1d1e0'
-};
-
-const assemblyInnerStyles = {
-  position: 'absolute',
-  left: '10px',
-  right: '10px',
-  top: '10px',
-  bottom: '10px',
-  background: '#f0f0f5',
-  border: '1px solid gray',
-  boxShadow: '0 2px 4px rgba(0, 0, 0, .48)'
-};
-
-const paragraphStyles = {
-  fontFamily: 'Helvetica Neue',
-  fontSize: '18px',
-  fontWeight: 'bold',
-  color: '#111',
-  paddingLeft: '20px'
-};
-
 class Scroll extends React.Component {
 
   constructor(props) {
@@ -39,33 +11,17 @@ class Scroll extends React.Component {
   }
 
   renderAssembies (item, index) {
-    return (
-          <div key={index} className="assembly" style={assemblyStyles}>
-            <div className="assembly-inner" style={assemblyInnerStyles}>
-              <p style={paragraphStyles}>{item.ciName}</p>
-                <Assembly key={index} item={item} organization={this.props.organization}></Assembly>
-            </div>
-          </div>
-          );
+    return ( <Assembly key={index} item={item} organization={this.props.organization}/> );
   }
 
   render() {
-    
     return (
-        <div>
-            <ScrollArea
-              className="area"
-              contentClassName="content"
-              smoothScrolling= {true}
-              minScrollSize={40}
-              onScroll={this.handleScroll} >
-              {
-                _.map(this.props.assemblies, (item, index) => {
-                  return this.renderAssembies(item, index);
-                })
-              }
-            </ScrollArea>
-        </div>
+      <ScrollArea
+        smoothScrolling={true}
+        minScrollSize={40}
+        onScroll={this.handleScroll} >
+        { _.map(this.props.assemblies, (item, index) => this.renderAssembies(item, index) ) }
+      </ScrollArea>
     );
   }
 }

--- a/src/app/components/select.jsx
+++ b/src/app/components/select.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {StyleRoot} from 'radium';
 
 /**
   Custom select input for the dropdown, similar to the implementation here:
@@ -24,27 +25,34 @@ class SelectComponent extends React.Component {
     );
 
     const selectStyles = {
+      '@media screen and (max-width: 800px)': {
+        height: '40px'
+      },
+      '@media screen and (min-width: 801px)': {
+        height: '100px'
+      },
       fontFamily: 'Helvetica Neue',
       fontSize: '20px',
       color: '#111',
       width: '100%',
       maxWidth: '100%',
-      height: '40px',
       textOverflow: 'ellipsis',
       border: '1px solid gray',
       boxShadow: '0 2px 4px rgba(0, 0, 0, .48)'
     };
 
     return (
-      <div style={{padding: '0px 10px 2px 10px'}}>
-        <select style={selectStyles}
-                defaultValue={'none'}
-                value={this.state.selected}
-                onChange={this.handleChange.bind(this)}>
-          {this.selectorLabel()}
-          {options}
-        </select>
-      </div>
+      <StyleRoot>
+        <div style={{padding: '0px 10px 2px 10px'}}>
+          <select style={[selectStyles]}
+                  defaultValue={'none'}
+                  value={this.state.selected}
+                  onChange={this.handleChange.bind(this)}>
+            {this.selectorLabel()}
+            {options}
+          </select>
+        </div>
+      </StyleRoot>
     );
   }
 }

--- a/src/app/components/select.jsx
+++ b/src/app/components/select.jsx
@@ -25,13 +25,30 @@ class SelectComponent extends React.Component {
     );
 
     const selectStyles = {
-      '@media screen and (max-width: 800px)': {
-        height: '40px'
+      '@media screen and (min-width:320px) and (max-width:479px)': {
+        /* smartphones, portrait iPhone, portrait 480x320 phones (Android) */
+        height:'200px'
       },
-      '@media screen and (min-width: 801px)': {
-        height: '100px'
+      '@media screen and (min-width:480px) and (max-width:599px)': {
+        /* smartphones, Android phones, landscape iPhone */
+        height:'200px'
       },
-      fontFamily: 'Helvetica Neue',
+      '@media screen and (min-width:600px) and (max-width:800px)': {
+        /* portrait tablets, portrait iPad, e-readers (Nook/Kindle), landscape 800x480 phones (Android) */
+        height:'200px'
+      },
+      '@media screen and (min-width:801px) and (max-width:1024px)': {
+        /* tablet, landscape iPad, lo-res laptops ands desktops */
+        height:'40px'
+      },
+      '@media screen and (min-width:1025px) and (max-width:1280px)': {
+        /* big landscape tablets, laptops, and desktops */
+        height:'40px'
+      },
+      '@media screen and (min-width:1281px)': {
+        /* hi-res laptops and desktops */
+        height:'40px'
+      },
       fontSize: '20px',
       color: '#111',
       width: '100%',

--- a/src/app/components/select.jsx
+++ b/src/app/components/select.jsx
@@ -15,12 +15,12 @@ class SelectComponent extends React.Component {
   }
 
   selectorLabel () {
-    return this.state.choice ? '' : <option value="none" selected>Select Organization</option>;
+    return this.state.choice ? undefined : <option value="none">Select Organization</option>;
   }
 
   render () {
     const options = this.props.options.map(
-      option => <option key={option} value={option}> {option} </option>
+      option => <option key={option} value={option}>{option}</option>
     );
 
     const selectStyles = {
@@ -37,7 +37,10 @@ class SelectComponent extends React.Component {
 
     return (
       <div style={{padding: '0px 10px 2px 10px'}}>
-        <select style={selectStyles} onChange={this.handleChange.bind(this)}>
+        <select style={selectStyles}
+                defaultValue={'none'}
+                value={this.state.selected}
+                onChange={this.handleChange.bind(this)}>
           {this.selectorLabel()}
           {options}
         </select>

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="favicon.ico" type="image/x-icon">
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   </head>
-  <body height="100%">
+  <body height="100%" style="font-family: Helvetica Neue">
     <div id="dropdown"></div>
     <div id="main"></div>
     <script src="app.js"></script>

--- a/src/app/store.jsx
+++ b/src/app/store.jsx
@@ -1,4 +1,4 @@
-import { createStore , compose } from 'redux';
+import { createStore } from 'redux';
 import { syncHistoryWithStore } from 'react-router-redux';
 import { browserHistory } from 'react-router';
 
@@ -6,8 +6,8 @@ import rootReducer from './reducers/index';
 
 //Create default store
 const defaultState = {
-	organizations: {selected: null , items: {}}
-}
+  organizations: { selected: null , items: {} }
+};
 
 const store = createStore(rootReducer , defaultState);
 

--- a/test/scroll-test.js
+++ b/test/scroll-test.js
@@ -10,6 +10,6 @@ const fakeAjax = function fakeAjax () {
 describe('<Scroll />', () => {
   const scroll = mount(<Scroll ajaxFunc={fakeAjax} ajaxParams={{}} />);
   const divs = scroll.find('div');
-  it('has three divs', () => { expect(divs).to.have.length.of(3); });
+  it('has 2 divs', () => { expect(divs).to.have.length.of(2); });
 
 });


### PR DESCRIPTION
 - clean up `select` warnings 
 - add `Radium` and media queries
 - clean up scroll component
 - add granular media queries to selector (experimental)
 - font for app in `index.html`
 - fix test
 - random whitespace cleanup