### PR TITLE
Issue #16: Webpack Split Bundles 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "test"
   ],
   "dependencies": {
-    "babel-core": "^6.4.5",
     "lodash": "^4.13.1",
     "onesie-toggle-environment-block": "latest",
     "radium": "^0.17.1",

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -9,6 +9,7 @@
   <body height="100%" style="font-family: Helvetica Neue; background-color: lightgrey">
     <div id="dropdown"></div>
     <div id="main"></div>
+    <script src="vendor.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,66 @@
+'use strict';
+
+
+/* Module Dependencies */
 var webpack = require('webpack');
+
+
+/* 
+  Entry Point Configurations:  
+  Multiple Entry Points Can Be Used For Breaking Up Bundles/Chunks
+  More Details: https://webpack.github.io/docs/multiple-entry-points.html
+*/
+var entryPointConfigs = {
+  app: [
+    'webpack-dev-server/client?http://127.0.0.1:8080', // WebpackDevServer host and port
+    'webpack/hot/only-dev-server', // "only" prevents reload on syntax errors
+    './index.js', // Your appʼs entry point,
+    './index.html'
+  ],
+  vendor: [
+    'lodash',
+    'radium',
+    'react',
+    'react-addons-update',
+    'react-dom',
+    'react-drop-down',
+    'react-redux',
+    'react-router',
+    'react-router-redux',
+    'react-scrollbar',
+    'redux',
+    'url-join'
+  ]
+};
+
+
+/*
+  Module Loader Configurations:
+  Loaders are used for front end build steps. They allow preprocessing of files as modules are sucked into the code (i.e. require/import)
+  More Details: https://webpack.github.io/docs/loaders.html
+*/
+var moduleLoaderConfigs = [
+  { test: /\.(js|jsx)$/, loaders: ['react-hot', 'babel?presets[]=react,presets[]=es2015'], exclude: /node_modules/ },
+  { test: /\.html$/, loader: 'file?name=[name].[ext]' },
+  { test: /\.css$/, loader: 'style-loader!css-loader' },
+  { test: /\.ico$/, loader: 'file-loader?name=[name].[ext]' }
+];
+
+
+/*
+  Plugin Configurations:
+  Plugins are super flexible and allow for custom code/extension implementations, which is great for custom build steps.
+  More Details: https://webpack.github.io/docs/plugins.html
+*/
+var pluginConfigs = [
+  new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.js'),
+  new webpack.HotModuleReplacementPlugin()
+];
+
 
 module.exports = {
   context: __dirname + '/src/app',
-  entry: [
-  'webpack-dev-server/client?http://127.0.0.1:8080', // WebpackDevServer host and port
-  'webpack/hot/only-dev-server', // "only" prevents reload on syntax errors
-  './index.js', // Your appʼs entry point,
-  './index.html'
-  ],
+  entry: entryPointConfigs,
   output: {
     filename: 'app.js',
     path: __dirname + '/dist'
@@ -16,19 +69,6 @@ module.exports = {
     modulesDirectories: ['node_modules', './src'],
     extensions: ['', '.js', '.jsx']
   },
-  module: {
-    loaders: [
-      {
-        test: /\.(js|jsx)$/, 
-        exclude: /node_modules/, 
-        loaders: ['react-hot', 'babel?presets[]=react,presets[]=es2015']
-      },
-      { test: /\.html$/, loader: 'file?name=[name].[ext]' },
-      { test: /\.css$/, loader: 'style-loader!css-loader' },
-      { test: /\.ico$/, loader: 'file-loader?name=[name].[ext]'}
-    ]
-  },
-  plugins : [
-    new webpack.HotModuleReplacementPlugin()
-  ]
+  module: { loaders: moduleLoaderConfigs },
+  plugins: pluginConfigs
 };


### PR DESCRIPTION
1. Added Multiple Entry Points to the webpack.config.js file: vendor and app.

2. Cleaned up webpack.config.js file by breaking up the configuration section into smaller configuration segments. After adding the Hot Reloader and the multiple entry points, the config was starting to get a little too large, and falling off the screen. 

3. Removed babel-core from the package.json file. It was duped with dependencies and devDependencies.

4. Updated index.html file with the new vendor.js bundle file.