### PR TITLE
adjusting scrollbar

### DIFF
--- a/src/app/components/expandedview.jsx
+++ b/src/app/components/expandedview.jsx
@@ -64,7 +64,7 @@ class ExpandedView extends React.Component {
     return (
       <div style={{padding: '1em'}}>
         <h3>{data.organization} > {data.assembly} > {data.name}</h3>
-        <div style={{display: 'flex', height: '35em', overflow: 'scroll'}}>
+        <div style={{display: 'flex', height: '35em', overflow: 'auto'}}>
           {_.map(data.platforms, (plat) => {
             index += 1;
             return this.renderPlatform(plat , index);

--- a/src/app/components/thumbview.jsx
+++ b/src/app/components/thumbview.jsx
@@ -49,7 +49,7 @@ class ThumbView extends React.Component {
         </div>
 
         {/* Body */}
-        <div className="thumbBody" style={{fontSize: '1em' , width: '100%' , height: '12em', overflow: 'scroll', padding: '0 .3em 0 0'}}>
+        <div className="thumbBody" style={{fontSize: '1em' , width: '100%' , height: '12em', overflow: 'auto', padding: '0 .3em 0 0'}}>
           {this.renderPlatforms()}
         </div>
 


### PR DESCRIPTION
Setting overflow to auto instead of scroll. This way, even if your OS setting is set to "always show scrollbar", it won't show the outline of a scrollbar unless there is scrollable content.
@ohall 